### PR TITLE
Sanitize vessel filenames

### DIFF
--- a/AtmosphereAutopilot/Modules/AutopilotModule.cs
+++ b/AtmosphereAutopilot/Modules/AutopilotModule.cs
@@ -104,7 +104,7 @@ namespace AtmosphereAutopilot
         public bool DeserializeVesselSpecific()
         {
             return AutoSerialization.Deserialize(this, module_name.Replace(' ', '_'),
-                KSPUtil.ApplicationRootPath + "GameData/AtmosphereAutopilot/designs/" + vessel.vesselName + ".txt",
+                KSPUtil.ApplicationRootPath + "GameData/AtmosphereAutopilot/designs/" + KSPUtil.SanitizeFilename(vessel.vesselName) + ".txt",
                 typeof(VesselSerializable), OnDeserialize);
         }
 

--- a/AtmosphereAutopilot/Modules/AutopilotModule.cs
+++ b/AtmosphereAutopilot/Modules/AutopilotModule.cs
@@ -125,7 +125,7 @@ namespace AtmosphereAutopilot
         {
             BeforeSerialized();
             AutoSerialization.Serialize(this, module_name.Replace(' ', '_'),
-                KSPUtil.ApplicationRootPath + "GameData/AtmosphereAutopilot/designs/" + vessel.vesselName + ".txt",
+                KSPUtil.ApplicationRootPath + "GameData/AtmosphereAutopilot/designs/" + KSPUtil.SanitizeFilename(vessel.vesselName) + ".txt",
                 typeof(VesselSerializable), OnSerialize);
             AutoSerialization.Serialize(this, module_name.Replace(' ', '_'),
                 KSPUtil.ApplicationRootPath + "GameData/AtmosphereAutopilot/Global_settings.txt",


### PR DESCRIPTION
Hi @Boris-Barboris! A user posted a log on the forum, and I noticed this while investigating:

https://forum.kerbalspaceprogram.com/index.php?/topic/206468-having-unexpected-mark-stack-overflow-and-other-unexpected-crashes-in-a-modded-install/

## Problem

If a user on Windows puts a `"` character in a vessel's name, this is seen in the log:

> [LOG 16:28:11.920] [AtmosphereAutopilot]: Serialization exception in path D:/Steam/steamapps/common/Kerbal Space Program/KSP_x64_Data/../GameData/AtmosphereAutopilot/designs/XR6 Launcher "amphibia".txt message Illegal characters in path.

This causes the serialization to fail. I don't know enough about AtmosphereAutopilot to assess what else might break downstream from this.

## Cause

[Windows doesn't allow certain characters in filenames](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file), including `"`, and AtmosphereAutopilot is trying to put user input into a filename without sanitizing it.

## Changes

Now this filename is passed through `KSPUtil.SanitizeFilename` before use (the same thing the stock game does with `.craft` files), so it will not contain illegal characters.
