### PR TITLE
Update IAS definition

### DIFF
--- a/AtmosphereAutopilot/AtmosphereAutopilot.cs
+++ b/AtmosphereAutopilot/AtmosphereAutopilot.cs
@@ -84,20 +84,15 @@ namespace AtmosphereAutopilot
         /// Current aerodynamics model.
         /// </summary>
         public static AerodinamycsModel AeroModel { get; private set; }
-        Assembly far_assembly;
+        public FARReflections farReflections;
 
         void determine_aerodynamics()
         {
             AeroModel = AerodinamycsModel.Stock;
-            foreach (var a in AppDomain.CurrentDomain.GetAssemblies())
+            farReflections = new FARReflections();
+            if (farReflections.isFarFound)
             {
-                if (a.GetName().Name.Equals("FerramAerospaceResearch"))
-                {
-                    far_assembly = a;
-                    AeroModel = AerodinamycsModel.FAR;
-                    Debug.Log("[AtmosphereAutopilot]: FAR aerodynamics detected");
-                    return;
-                }
+                AeroModel = AerodinamycsModel.FAR;
             }
         }
 
@@ -111,11 +106,7 @@ namespace AtmosphereAutopilot
             if (AeroModel == AerodinamycsModel.Stock)
                 control_surface_module_type = typeof(SyncModuleControlSurface);
             else
-            {
-                control_surface_module_type = far_assembly.GetTypes().First(t => t.Name.Equals("FARControllableSurface"));
-                if (control_surface_module_type == null)
-                    throw new Exception("AtmosphereAutopilot could not bind to FAR FARControllableSurface class");
-            }
+                control_surface_module_type = farReflections.FARControllableSurfaceType;
         }
 
         public static Dictionary<Type, ConstructorInfo> gimbal_module_wrapper_map = new Dictionary<Type, ConstructorInfo>(4);

--- a/AtmosphereAutopilot/AtmosphereAutopilot.csproj
+++ b/AtmosphereAutopilot/AtmosphereAutopilot.csproj
@@ -102,6 +102,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutoHotkey.cs" />
+    <Compile Include="Reflections\FARReflections.cs" />
     <Compile Include="GimbalWrappers.cs" />
     <Compile Include="AppLauncher.cs" />
     <Compile Include="AtmosphereAutopilot.cs" />
@@ -157,6 +158,7 @@
     <Compile Include="Modules\TopModuleManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MessageManager.cs" />
+    <Compile Include="Reflections\ReflectionUtils.cs" />
     <Compile Include="SyncModuleControlSurface.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/AtmosphereAutopilot/GUI/NeoGUIController.cs
+++ b/AtmosphereAutopilot/GUI/NeoGUIController.cs
@@ -132,13 +132,13 @@ namespace AtmosphereAutopilot {
       get {
         if (speedAP == null)
           return 0f;
-        return speedAP.setpoint.mps();
+        return speedAP.setpoint.sameSystemMps();
       }
 
       set {
         if (parent.ActiveVessel != null) {
           speedAP.setpoint_field.Value = value;
-          speedAP.chosen_spd_mode = 1;
+          speedAP.type = SpeedType.MetersPerSecond;
           speedAP.setpoint = new SpeedSetpoint(SpeedType.MetersPerSecond, value, parent.ActiveVessel);
         }
       }

--- a/AtmosphereAutopilot/Modules/AoAHoldController.cs
+++ b/AtmosphereAutopilot/Modules/AoAHoldController.cs
@@ -115,7 +115,7 @@ namespace AtmosphereAutopilot
                 return;
 
             if (thrust_c.spd_control_enabled)
-                thrust_c.ApplyControl(cntrl, thrust_c.setpoint.mps());
+                thrust_c.ApplyControl(cntrl);
 
             if (use_keys)
                 ControlUtils.neutralize_user_input(cntrl, PITCH);

--- a/AtmosphereAutopilot/Modules/CruiseController.cs
+++ b/AtmosphereAutopilot/Modules/CruiseController.cs
@@ -87,7 +87,7 @@ namespace AtmosphereAutopilot
                 return;
 
             if (thrust_c.spd_control_enabled)
-                thrust_c.ApplyControl(cntrl, thrust_c.setpoint.mps());
+                thrust_c.ApplyControl(cntrl);
 
             desired_velocity = Vector3d.zero;
             planet2ves = vessel.ReferenceTransform.position - vessel.mainBody.position;
@@ -320,14 +320,15 @@ namespace AtmosphereAutopilot
                     else
                         effective_max_climb_angle = 1.0;
 
-                    double spd_diff = (imodel.surface_v_magnitude - thrust_c.setpoint.mps());
+                    double spd_diff_magnitude;
+                    double spd_diff = thrust_c.speedDiff(out spd_diff_magnitude);
                     if (spd_diff < -flc_margin)
                         effective_max_climb_angle *= 0.0;
                     else if (spd_diff < 0.0)
-                        effective_max_climb_angle *= (spd_diff + flc_margin) / flc_margin;
+                        effective_max_climb_angle *= (spd_diff * spd_diff_magnitude + flc_margin) / flc_margin;
                 }
                 else
-                    effective_max_climb_angle *= Math.Max(0.0, Math.Min(1.0, vessel.srfSpeed / thrust_c.setpoint.mps()));
+                    effective_max_climb_angle *= Common.Clamp(thrust_c.currentSpeedOfSameSystem() / thrust_c.setpoint.sameSystemMps(), 0.0, 1.0);
             }
 
             double max_vert_speed = vessel.horizontalSrfSpeed * Math.Tan(effective_max_climb_angle * dgr2rad);

--- a/AtmosphereAutopilot/Modules/MouseDirector.cs
+++ b/AtmosphereAutopilot/Modules/MouseDirector.cs
@@ -66,7 +66,7 @@ namespace AtmosphereAutopilot
             dir_c.ApplyControl(cntrl, camera_direction, Vector3d.zero);
 
             if (thrust_c.spd_control_enabled)
-                thrust_c.ApplyControl(cntrl, thrust_c.setpoint.mps());
+                thrust_c.ApplyControl(cntrl);
         }
 
         //bool camera_correct = false;

--- a/AtmosphereAutopilot/Modules/ProgradeThrustController.cs
+++ b/AtmosphereAutopilot/Modules/ProgradeThrustController.cs
@@ -40,96 +40,6 @@ namespace AtmosphereAutopilot
         public const float kts2mps = 0.514444f;
         public const float mps2kts = 1.0f / kts2mps;
 
-        public const float machEpsilon = 0.005f;
-
-        public static float rayleighPitotTubeStagPressureSubSonic(float M, float gamma)
-        {
-            float pressure;
-
-            pressure = (M * M) * (gamma - 1) / 2 + 1;
-            pressure = Mathf.Pow(pressure, gamma / (gamma - 1));
-
-            return pressure;
-        }
-
-        public static float rayleighPitotTubeStagPressureSuperSonic(float M, float gamma)
-        {
-            float pressure;
-
-            pressure = (gamma + 1) * M;
-            pressure *= pressure;
-            pressure /= (4 * gamma * M * M - 2 * (gamma - 1));
-            pressure = Mathf.Pow(pressure, gamma / (gamma - 1));
-            pressure *= (1 - gamma + 2 * gamma * M * M) / (gamma + 1);
-
-            return pressure;
-        }
-
-        public static float mps2Ias(float mps, Vessel v)
-        {
-            float M = (float)(mps / v.speedOfSound);
-            float gamma = (float) v.mainBody.atmosphereAdiabaticIndex;
-            float pressureRatio;
-            if (M <= 1)
-            {
-                pressureRatio = rayleighPitotTubeStagPressureSubSonic(M, gamma);
-            }
-            else
-            {
-                pressureRatio = rayleighPitotTubeStagPressureSuperSonic(M, gamma);
-            }
-
-            float velocity = pressureRatio - 1;
-            velocity *= (float)v.staticPressurekPa * 1000 * 2;
-            velocity /= 1.225f;
-            velocity = Mathf.Sqrt(velocity);
-            return velocity;
-        }
-
-        public static float rayleighMachFromPitotTubeStagPressure(float pressure, float gamma)
-        {
-            float M;
-
-            float soundPres = Mathf.Pow((gamma + 1) / 2, gamma / (gamma - 1)); ;
-
-            if (pressure <= soundPres)
-            {
-                M = Mathf.Pow(pressure, (gamma - 1) / gamma);
-                M = (M - 1) * 2 / (gamma - 1);
-                M = Mathf.Sqrt(M);
-            }
-            else
-            {
-                float slope, mnew;
-                float m1 = 1, m2 = 2;
-                float pt1 = rayleighPitotTubeStagPressureSuperSonic(m1, gamma) - pressure;
-                float pt2 = rayleighPitotTubeStagPressureSuperSonic(m2, gamma) - pressure;
-                do
-                {
-                    slope = (m2 - m1) / (pt2 - pt1);
-                    mnew = m2 - slope * pt2;
-                    mnew = Mathf.Max(1, mnew); // don't go subsonic
-                    m1 = m2;
-                    m2 = mnew;
-                    pt1 = pt2;
-                    pt2 = rayleighPitotTubeStagPressureSuperSonic(m2, gamma) - pressure;
-                } while (Mathf.Abs(m2 - m1) > machEpsilon);
-                M = m2;
-            }
-            return M;
-        }
-
-        public static float ias2Mps(float ias, Vessel v)
-        {
-            float gamma = (float)v.mainBody.atmosphereAdiabaticIndex;
-
-            float pressureRatio = ias * ias * 1.225f / (float)v.staticPressurekPa / 1000 / 2 + 1;
-
-            float M = rayleighMachFromPitotTubeStagPressure(pressureRatio, gamma);
-
-            return (float) (M * v.speedOfSound);
-        }
-
         public SpeedSetpoint(SpeedType type, float value, Vessel v)
         {
             this.type = type;
@@ -151,9 +61,9 @@ namespace AtmosphereAutopilot
                 case SpeedType.Knots:
                     return mpersec * mps2kts;
                 case SpeedType.IAS:
-                    return mps2Ias(mpersec, v);
+                    return Mathf.Sqrt(mpersec * mpersec * (float)v.atmDensity);
                 case SpeedType.KIAS:
-                    return mps2Ias(mpersec, v) * mps2kts;
+                    return Mathf.Sqrt(mpersec * mpersec * mps2kts * mps2kts * (float)v.atmDensity);
                 default:
                     return 0.0f;
             }
@@ -170,9 +80,9 @@ namespace AtmosphereAutopilot
                 case SpeedType.Knots:
                     return mps * mps2kts;
                 case SpeedType.IAS:
-                    return mps2Ias(mps, v);
+                    return Mathf.Sqrt(mps * mps * (float)v.atmDensity);
                 case SpeedType.KIAS:
-                    return mps2Ias(mps, v) * mps2kts;
+                    return Mathf.Sqrt(mps * mps * mps2kts * mps2kts * (float)v.atmDensity);
                 default:
                     return 0.0f;
             }
@@ -189,9 +99,9 @@ namespace AtmosphereAutopilot
                 case SpeedType.Knots:
                     return value * kts2mps;
                 case SpeedType.IAS:
-                    return ias2Mps(value, v);
+                    return Mathf.Sqrt(value * value / (float)v.atmDensity);
                 case SpeedType.KIAS:
-                    return ias2Mps(value * kts2mps, v);
+                    return Mathf.Sqrt(value * value * kts2mps * kts2mps / (float)v.atmDensity);
                 default:
                     return 0.0f;
             }

--- a/AtmosphereAutopilot/Modules/StandardFlyByWire.cs
+++ b/AtmosphereAutopilot/Modules/StandardFlyByWire.cs
@@ -202,7 +202,7 @@ namespace AtmosphereAutopilot
             }
 
             if (tc.spd_control_enabled)
-                tc.ApplyControl(cntrl, tc.setpoint.mps());
+                tc.ApplyControl(cntrl);
 
 			pc.user_controlled = true;
             if (coord_turn)

--- a/AtmosphereAutopilot/Modules/StateController.cs
+++ b/AtmosphereAutopilot/Modules/StateController.cs
@@ -40,6 +40,23 @@ namespace AtmosphereAutopilot
     }
 
     /// <summary>
+    /// Base class of sub state controllers that is called by main state controllers
+    /// </summary>
+    public abstract class SubStateController : AutopilotModule
+    {
+        protected SubStateController(Vessel cur_vessel, string module_name, int wnd_id)
+            : base(cur_vessel, wnd_id, module_name)
+        { }
+
+        /// <summary>
+        /// Main control function of the sub autopilot.
+        /// </summary>
+        /// <param name="cntrl">Control state to change</param>
+        public abstract void ApplyControl(FlightCtrlState cntrl);
+
+    }
+
+    /// <summary>
     /// Flight control state controller with SIMO base class
     /// </summary>
     public abstract class SISOController : AutopilotModule

--- a/AtmosphereAutopilot/Reflections/FARReflections.cs
+++ b/AtmosphereAutopilot/Reflections/FARReflections.cs
@@ -1,0 +1,96 @@
+﻿/*
+Atmosphere Autopilot, plugin for Kerbal Space Program.
+Copyright (C) 2015-2016, Baranin Alexander aka Boris-Barboris.
+
+Atmosphere Autopilot is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+Atmosphere Autopilot is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with Atmosphere Autopilot.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+using System;
+using System.Reflection;
+using UnityEngine;
+
+namespace AtmosphereAutopilot
+{
+    public class FARReflections
+    {
+        public Assembly farAssembly;
+        public bool isFarFound = false;
+
+        public Type FARControllableSurfaceType;
+
+        public delegate double ActiveVesselIASDelegateType();
+        public ActiveVesselIASDelegateType ActiveVesselIASDelegate;
+
+        public delegate double RayleighPitotTubeStagPressureDelegateType(double M);
+        public RayleighPitotTubeStagPressureDelegateType RayleighPitotTubeStagPressureDelegate;
+
+        public FARReflections()
+        {
+            farAssembly = ReflectionUtils.GetAssembly("FerramAerospaceResearch");
+
+            if (farAssembly != null)
+            {
+                Debug.Log("[AtmosphereAutopilot]: FAR aerodynamics detected");
+                isFarFound = true;
+
+                // Get FAR control surface type
+                FARControllableSurfaceType = ReflectionUtils.GetType(farAssembly, "FARControllableSurface");
+                if (FARControllableSurfaceType == null)
+                {
+                    throw new Exception("AtmosphereAutopilot could not bind to FAR FARControllableSurface class");
+                }
+
+                // Load ActiveVesselIAS method from FARAPI
+                var activeVesselIASMethodInfo = ReflectionUtils.GetMethodInfo(
+                    farAssembly,
+                    "FerramAerospaceResearch.FARAPI",
+                    "ActiveVesselIAS",
+                    BindingFlags.Public | BindingFlags.Static);
+
+                if (activeVesselIASMethodInfo == null)
+                {
+                    Debug.LogWarning("[AtmosphereAutopilot]: FAR ActiveVesselIAS() method reflection failed, disabling FAR IAS support");
+                    // don't load other methods if ActiveVesselIAS fails
+                    return;
+                } 
+                else
+                {
+                    ActiveVesselIASDelegate = (ActiveVesselIASDelegateType)
+                        Delegate.CreateDelegate(
+                            typeof(ActiveVesselIASDelegateType),
+                            activeVesselIASMethodInfo);
+                }
+                
+                // Load undocumented RayleighPitotTubeStagPressure method from FAR
+                var rayleighPitotTubeStagPressureMethodInfo = ReflectionUtils.GetMethodInfo(
+                    farAssembly,
+                    "FerramAerospaceResearch.FARAeroUtil",
+                    "RayleighPitotTubeStagPressure",
+                    BindingFlags.Public | BindingFlags.Static,
+                    new Type[] { typeof(double) });
+
+                if (rayleighPitotTubeStagPressureMethodInfo == null)
+                {
+                    Debug.LogWarning("[AtmosphereAutopilot]: FAR RayleighPitotTubeStagPressure() method reflection failed, reverting to EAS speed conversions");
+                }
+                else
+                {
+                    RayleighPitotTubeStagPressureDelegate = (RayleighPitotTubeStagPressureDelegateType)
+                        Delegate.CreateDelegate(
+                            typeof(RayleighPitotTubeStagPressureDelegateType),
+                            rayleighPitotTubeStagPressureMethodInfo);
+                }
+            }
+        }
+    }
+}

--- a/AtmosphereAutopilot/Reflections/ReflectionUtils.cs
+++ b/AtmosphereAutopilot/Reflections/ReflectionUtils.cs
@@ -1,0 +1,58 @@
+﻿/*
+Atmosphere Autopilot, plugin for Kerbal Space Program.
+Copyright (C) 2015-2016, Baranin Alexander aka Boris-Barboris.
+
+Atmosphere Autopilot is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+Atmosphere Autopilot is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with Atmosphere Autopilot.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace AtmosphereAutopilot
+{
+    public static class ReflectionUtils
+    {
+        public static Assembly GetAssembly(string module)
+        {
+            foreach (var a in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (a.GetName().Name.Equals(module))
+                {
+                    return a;
+                }
+            }
+            return null;
+        }
+        public static MethodInfo GetMethodInfo(Assembly assembly, string className, string methodName, BindingFlags flags, Type[] args = null)
+        {
+            if (assembly == null)
+                return null;
+
+            Type type = assembly.GetType(className, false);
+
+            if (type == null)
+                return null;
+
+            if (args == null)
+                args = Type.EmptyTypes;
+
+            return type.GetMethod(methodName, flags, null, args, null);
+        }
+
+        public static Type GetType(Assembly assembly, string typeName)
+        {
+            return assembly.GetTypes().First(t => t.Name.Equals(typeName));
+        }
+    }
+}


### PR DESCRIPTION
Hi Boris!
I'm [2Fat2Fly on KSP forum](https://forum.kerbalspaceprogram.com/index.php?/profile/149977-2fat2fly/) (previously Fat_Bird).

First of all thanks for your amazing addon which is still the best among the autopilot plugins for KSP IMO!
I've picked up KSP again recently and now I'm comming back to try to solve [several issues mentioned several years ago](https://forum.kerbalspaceprogram.com/index.php?/topic/124417-180-1123-atmosphereautopilot-160/&do=findComment&comment=2462486). I've split the changes to several branches to better describe them one by one. This being the first of them.

# Indicated Airspeed (IAS) Definition Update

## The issue

In the previous code, the "IAS" was defined using true airspeed (ground speed) against atmosphere density:
https://github.com/Boris-Barboris/AtmosphereAutopilot/blob/6d21fdbedcb51bf1f75c1b3c973a5bd2f755986b/AtmosphereAutopilot/Modules/ProgradeThrustController.cs#L64
Of which is actualy [equivalent airspeed (EAS) by definition](https://en.wikipedia.org/wiki/Equivalent_airspeed).

However, as quoted from the [IAS Wikipedia page](https://en.wikipedia.org/wiki/Indicated_airspeed):

> However, at typical civilian operating speeds, the aircraft's aerodynamic structure responds to dynamic pressure alone, and the aircraft will perform the same when at the same dynamic pressure. Since it is this same dynamic pressure that drives the airspeed indicator, an aircraft will always, for example, stall at the published indicated airspeed (for the current configuration) regardless of density, altitude or true airspeed.

So I think it is necessary to tell the autopilot to stick to a certain IAS, instead of a certain EAS.

## Solution

In the Prograde Thrust Controller module, I replicated [the FARc's code](https://github.com/dkavolis/Ferram-Aerospace-Research/blob/49449b5fc833eef87f1e749ef80883bc1111d7ce/FerramAerospaceResearch/FARAeroUtil.cs#L323) to calculate IAS, as below:
https://github.com/T2Fat2Fly/AtmosphereAutopilot/blob/1a909acf1974c5f59ba366451969645d80ea1655/AtmosphereAutopilot/Modules/ProgradeThrustController.cs#L68
But since the code have nothing to do with FARc, it should work with stock aerodynamic as well.

Since the PTC module uses mps (ground speed) as setpoint for thrust control, a reverse function is also included, which involved secant method for the supersonic part. Luckily it seems not to have a significant performance hit in game.

## Result

FAR stock aircraft FAR Firehound MS used as example. It seems that a good consistency with the FARc IAS is established, both subsonically and supersonically:
![pic1](https://user-images.githubusercontent.com/55565923/200815400-eb8bd9da-d485-4164-9a77-a7664f81897d.png)
![pic2](https://user-images.githubusercontent.com/55565923/200815429-beb0cd8e-6823-424b-98b6-3d3be531a4e2.png)
![pic3](https://user-images.githubusercontent.com/55565923/200815452-29c1e3b0-8bfc-4894-a376-3a8342b4bb27.png)
