### PR TITLE
Avoiding Assembly Binder Errors

### DIFF
--- a/AtmosphereAutopilot/Properties/AssemblyInfo.GUI.cs
+++ b/AtmosphereAutopilot/Properties/AssemblyInfo.GUI.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: KSPAssembly("AtmosphereAutopilot.GUI", 1, 0)]

--- a/AtmosphereAutopilot/Properties/AssemblyInfo.cs
+++ b/AtmosphereAutopilot/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.6.0.0")]
 [assembly: AssemblyFileVersion("1.6.0.0")]
+[assembly: KSPAssemblyDependency("AtmosphereAutopilot.GUI", 1, 0)]


### PR DESCRIPTION
This is the bare minimum to prevent Assembly Binder errors during load. It should have no effect on AA itself, but should save mods lower in the load order from issues.

AssemblyInfo.cs should probably get its own KSPAssembly entry, but this is beyond the scope of the preventative fix.
Kerbal Engineer has more extensive examples of this.