### PR TITLE
Prevents AA from going 737 MAX when a typo is entered on the GUI's text entries

### DIFF
--- a/AtmosphereAutopilot/AtmosphereAutopilot.csproj
+++ b/AtmosphereAutopilot/AtmosphereAutopilot.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MessageManager.cs" />
     <Compile Include="SyncModuleControlSurface.cs" />
+    <Compile Include="GUI\DelayedField\DelayedFieldGeoCoordinates.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="GUI\DelayedField\DelayedField.ttinclude" />

--- a/AtmosphereAutopilot/GUI/DelayedField/DelayedField.ttinclude
+++ b/AtmosphereAutopilot/GUI/DelayedField/DelayedField.ttinclude
@@ -63,7 +63,7 @@ namespace AtmosphereAutopilot
         /// </summary>
         /// <param name="init_value">Initial value</param>
         /// <param name="format"></param>
-        public DelayedFieldFloat(<#= typename #> init_value, string format)
+        public DelayedField<#= Postfix #>(<#= typename #> init_value, string format)
         {
             val = init_value;
             time = 0.0f;
@@ -111,7 +111,13 @@ namespace AtmosphereAutopilot
             {
                 time = 0.0f;
                 changed = false;
-                <#= typename #>.TryParse(input_str, out val);
+                {
+                    <#= typename #> v;
+                    if (<#= typename #>.TryParse(input_str, out v))
+                        this.val = v;
+                    else
+                        this.input_str = this.val.ToString(format_str);
+                }
             }
         }
 

--- a/AtmosphereAutopilot/GUI/DelayedField/DelayedFieldFloat.cs
+++ b/AtmosphereAutopilot/GUI/DelayedField/DelayedFieldFloat.cs
@@ -171,8 +171,14 @@ namespace AtmosphereAutopilot
 						if (dms.Length > 1) return;	// wait for NS/EW
 					}
 				}
-                float.TryParse(input_str, out val);
-			}
+                {
+                    float v;
+                    if (float.TryParse(input_str, out v))
+                        this.val = v;
+                    else
+                        this.input_str = this.val.ToString(format_str);
+                }
+            }
         }
 
 		public override string ToString()

--- a/AtmosphereAutopilot/GUI/DelayedField/DelayedFieldFloat.cs
+++ b/AtmosphereAutopilot/GUI/DelayedField/DelayedFieldFloat.cs
@@ -19,34 +19,31 @@ along with Atmosphere Autopilot.  If not, see <http://www.gnu.org/licenses/>.
 //
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace AtmosphereAutopilot
 {
 
     /// <summary>
-    /// Struct for organizing delayed textfield input. Use DisplayLayout() to integrate into OnGUI code,
-	/// use OnUpdate() to account for time.
+    /// Class for organizing delayed textfield input. Use DisplayLayout() to integrate into OnGUI code,
+    /// use OnUpdate() to account for time.
     /// </summary>
-    public struct DelayedFieldFloat
+    public class DelayedFieldFloat
     {
         /// <summary>
         /// Underlying float value to represent
         /// </summary>
-        float val;
+        protected float val;
 
         /// <summary>
         /// Time in seconds after input string was changed by user input
         /// </summary>
-        float time;
+        protected float time;
 
         /// <summary>
         /// true when we're counting time
         /// </summary>
-        bool changed;
+        protected bool changed;
 
         /// <summary>
         /// String that holds input value
@@ -58,30 +55,21 @@ namespace AtmosphereAutopilot
         /// </summary>
         public string format_str;
 
-	    /// <summary>
-	    /// lat/lon may be entered in deg min secHemi format
-	    /// e.g. 74 39 39W
-	    /// Only permits entry via OnUpdate; not via the setter
-	    /// </summary>
-	    public enum CoordFormat { Decimal, NS, EW };
-		public CoordFormat coord_format;
-
         /// <summary>
         /// 
         /// </summary>
         /// <param name="init_value">Initial value</param>
         /// <param name="format"></param>
         public DelayedFieldFloat(
-			float init_value,
-			string format,
-			CoordFormat coord_fmt = CoordFormat.Decimal)
+            float init_value
+            , string format
+        )
         {
             val = init_value;
             time = 0.0f;
             changed = false;
             input_str = val.ToString(format);
             format_str = format;
-	        coord_format = coord_fmt;
         }
 
         public static implicit operator float(DelayedFieldFloat f)
@@ -104,7 +92,7 @@ namespace AtmosphereAutopilot
             }
         }
 
-		public void DisplayLayout(GUIStyle style, params GUILayoutOption[] options)
+        public void DisplayLayout(GUIStyle style, params GUILayoutOption[] options)
         {
             string new_str = GUILayout.TextField(input_str, style, options);
             if (!input_str.Equals(new_str))
@@ -115,12 +103,7 @@ namespace AtmosphereAutopilot
             input_str = new_str;
         }
 
-		public CoordFormat check_coord_format()
-		{
-			return coord_format;
-		}
-
-		public void OnUpdate()
+        public void OnUpdate()
         {
             if (changed)
                 time += Time.deltaTime;
@@ -128,49 +111,6 @@ namespace AtmosphereAutopilot
             {
                 time = 0.0f;
                 changed = false;
-				if (coord_format != CoordFormat.Decimal) {
-					// attempt to decode dms format indicated by NO leading
-					// magnitude sign and by a trailing N, S, E or W
-					var trimmed = input_str.Trim();
-					var len = trimmed.Length;
-					if (len > 0 && trimmed[0] != '+' && trimmed[0] != '-')
-					{
-						var last = trimmed[len - 1];
-						int sign = 0;
-						if (coord_format == CoordFormat.NS)
-						{
-							if (last == 'S' || last == 's') sign = -1;
-							else if (last == 'N' || last == 'n') sign = 1;
-						}
-						else
-						{
-							if (last == 'W' || last == 'w') sign = -1;
-							else if (last == 'E' || last == 'e') sign = 1;
-						}
-						trimmed = trimmed.Substring(0, len - 1);
-						var dms = trimmed.Split(' ');
-						if (sign != 0)
-						{
-							int num;
-							int.TryParse(dms[0], out num);
-							val = sign * num;
-							if (dms.Length > 1)
-							{
-								int.TryParse(dms[1], out num);
-								val += sign * num / 60.0f;
-								if (dms.Length > 2)
-								{
-									int.TryParse(dms[1], out num);
-									val += sign * num / 3600.0f;
-								}
-							}
-							input_str = val.ToString(format_str);	// feedback
-							Debug.Log($"[AtmosphereAutopilot] coords {val:F4}");
-							return;
-						}
-						if (dms.Length > 1) return;	// wait for NS/EW
-					}
-				}
                 {
                     float v;
                     if (float.TryParse(input_str, out v))
@@ -181,7 +121,7 @@ namespace AtmosphereAutopilot
             }
         }
 
-		public override string ToString()
+        public override string ToString()
         {
             return val.ToString() + "_" + format_str;
         }
@@ -195,9 +135,9 @@ namespace AtmosphereAutopilot
         {
             int delim_index = str.IndexOf('_');
             if (delim_index < 0)
-			{
-				return new DelayedFieldFloat(0.0f, "G4");
-			}
+            {
+                return new DelayedFieldFloat(0.0f, "G4");
+            }
             else
             {
                 string val_str = str.Substring(0, delim_index);

--- a/AtmosphereAutopilot/GUI/DelayedField/DelayedFieldGeoCoordinates.cs
+++ b/AtmosphereAutopilot/GUI/DelayedField/DelayedFieldGeoCoordinates.cs
@@ -1,0 +1,115 @@
+﻿/*
+Atmosphere Autopilot, plugin for Kerbal Space Program.
+Copyright (C) 2015-2016, Baranin Alexander aka Boris-Barboris.
+Copyright (C) 2016, George Sedov.
+
+Atmosphere Autopilot is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+Atmosphere Autopilot is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with Atmosphere Autopilot.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using UnityEngine;
+
+namespace AtmosphereAutopilot
+{
+    /// <summary>
+    /// Struct for organizing delayed textfield input. Use DisplayLayout() to integrate into OnGUI code,
+    /// use OnUpdate() to account for time.
+    /// </summary>
+    public class DelayedFieldGeoCoordinates : DelayedFieldFloat
+    {
+        /// <summary>
+        /// lat/lon may be entered in deg min secHemi format
+        /// e.g. 74 39 39W
+        /// Only permits entry via OnUpdate; not via the setter
+        /// </summary>
+        public enum CoordFormat { Decimal, NS, EW };
+        public CoordFormat coord_format;
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="init_value">Initial value</param>
+        /// <param name="format"></param>
+        public DelayedFieldGeoCoordinates(
+            float init_value,
+            string format,
+            CoordFormat coord_fmt = CoordFormat.Decimal) : base(init_value, format)
+        {
+            coord_format = coord_fmt;
+        }
+
+        public CoordFormat check_coord_format()
+        {
+            return coord_format;
+        }
+
+        public new void OnUpdate()
+        {
+            if (changed)
+                time += Time.deltaTime;
+            if (time >= 2.0f)
+            {
+                time = 0.0f;
+                changed = false;
+				if (coord_format != CoordFormat.Decimal) {
+					// attempt to decode dms format indicated by NO leading
+					// magnitude sign and by a trailing N, S, E or W
+					var trimmed = input_str.Trim();
+					var len = trimmed.Length;
+					if (len > 0 && trimmed[0] != '+' && trimmed[0] != '-')
+					{
+						var last = trimmed[len - 1];
+						int sign = 0;
+						if (coord_format == CoordFormat.NS)
+						{
+							if (last == 'S' || last == 's') sign = -1;
+							else if (last == 'N' || last == 'n') sign = 1;
+						}
+						else
+						{
+							if (last == 'W' || last == 'w') sign = -1;
+							else if (last == 'E' || last == 'e') sign = 1;
+						}
+						trimmed = trimmed.Substring(0, len - 1);
+						var dms = trimmed.Split(' ');
+						if (sign != 0)
+						{
+							int num;
+							int.TryParse(dms[0], out num);
+							val = sign * num;
+							if (dms.Length > 1)
+							{
+								int.TryParse(dms[1], out num);
+								val += sign * num / 60.0f;
+								if (dms.Length > 2)
+								{
+									int.TryParse(dms[1], out num);
+									val += sign * num / 3600.0f;
+								}
+							}
+							input_str = val.ToString(format_str);	// feedback
+							Log.info("[AtmosphereAutopilot] coords {0:F4}", val);
+							return;
+						}
+						if (dms.Length > 1) return;	// wait for NS/EW
+					}
+				}
+                {
+                    float v;
+                    if (float.TryParse(input_str, out v))
+                        this.val = v;
+                    else
+                        this.input_str = this.val.ToString(format_str);
+                }
+            }
+        }
+    }
+}

--- a/AtmosphereAutopilot/GUI/DelayedField/DelayedFieldGeoCoordinates.cs
+++ b/AtmosphereAutopilot/GUI/DelayedField/DelayedFieldGeoCoordinates.cs
@@ -96,7 +96,7 @@ namespace AtmosphereAutopilot
 								}
 							}
 							input_str = val.ToString(format_str);	// feedback
-							Log.info("[AtmosphereAutopilot] coords {0:F4}", val);
+							Debug.LogFormat("[AtmosphereAutopilot] coords {0:F4}", val);
 							return;
 						}
 						if (dms.Length > 1) return;	// wait for NS/EW

--- a/AtmosphereAutopilot/Modules/AngularVelAdaptiveController.cs
+++ b/AtmosphereAutopilot/Modules/AngularVelAdaptiveController.cs
@@ -151,6 +151,11 @@ namespace AtmosphereAutopilot
         [VesselSerializable("max_v_construction")]
         [AutoGuiAttr("Max v construction", true, "G6")]
         public float max_v_construction = 0.7f;
+        public string max_v_construction_as_text
+        {
+            set => this.max_v_construction = float.TryParse(value, out float v) ? v : this.max_v_construction;
+            get => this.max_v_construction.ToString("G6");
+        }
 
         protected virtual float process_desired_v(float des_v, bool user_input) { return des_v; }
 
@@ -620,10 +625,20 @@ namespace AtmosphereAutopilot
         [VesselSerializable("max_aoa")]
         [AutoGuiAttr("max AoA", true, "G6")]
         public float max_aoa = 15.0f;
+        public string max_aoa_as_text
+        {
+            set => this.max_aoa = float.TryParse(value, out float v) ? v : this.max_aoa;
+            get => this.max_aoa.ToString("G6");
+        }
 
         [VesselSerializable("max_g_force")]
         [AutoGuiAttr("max G-force", true, "G6")]
         public float max_g_force = 15.0f;
+        public string max_g_force_as_text
+        {
+            set => this.max_g_force = float.TryParse(value, out float v) ? v : this.max_g_force;
+            get => this.max_g_force.ToString("G8");
+        }
     }
 
     public sealed class PitchAngularVelocityController : PitchYawAngularVelocityController

--- a/AtmosphereAutopilot/Modules/CruiseController.cs
+++ b/AtmosphereAutopilot/Modules/CruiseController.cs
@@ -234,10 +234,10 @@ namespace AtmosphereAutopilot
         public DelayedFieldFloat desired_course = new DelayedFieldFloat(90.0f, "G4");
 
         [VesselSerializable("desired_latitude_field")]
-        public DelayedFieldFloat desired_latitude = new DelayedFieldFloat(-0.0486178f, "#0.0000", DelayedFieldFloat.CoordFormat.NS);  // latitude of KSC runway, west end (default position for launched vessels)
+        public DelayedFieldGeoCoordinates desired_latitude = new DelayedFieldGeoCoordinates(-0.0486178f, "#0.0000", DelayedFieldGeoCoordinates.CoordFormat.NS);  // latitude of KSC runway, west end (default position for launched vessels)
 
         [VesselSerializable("desired_longitude_field")]
-        public DelayedFieldFloat desired_longitude = new DelayedFieldFloat(-74.72444f, "#0.0000", DelayedFieldFloat.CoordFormat.EW);  // longitude of KSC runway, west end (default position for launched vessels)
+        public DelayedFieldGeoCoordinates desired_longitude = new DelayedFieldGeoCoordinates(-74.72444f, "#0.0000", DelayedFieldGeoCoordinates.CoordFormat.EW);  // longitude of KSC runway, west end (default position for launched vessels)
 
         [VesselSerializable("vertical_control")]
         public bool vertical_control = false;
@@ -897,9 +897,9 @@ namespace AtmosphereAutopilot
             desired_course.OnUpdate();
 			// why didn't the desired_latitude constructor initialize this properly?  unknown
 			// possibly the combination of VS2017 and .NET 3.3?
-			desired_latitude.coord_format = DelayedFieldFloat.CoordFormat.NS;
+			desired_latitude.coord_format = DelayedFieldGeoCoordinates.CoordFormat.NS;
 	        desired_latitude.OnUpdate();
-			desired_longitude.coord_format = DelayedFieldFloat.CoordFormat.EW;
+			desired_longitude.coord_format = DelayedFieldGeoCoordinates.CoordFormat.EW;
 	        desired_longitude.OnUpdate();
             desired_altitude.OnUpdate();
             desired_vertsetpoint.OnUpdate();

--- a/AtmosphereAutopilot/Modules/DirectorController.cs
+++ b/AtmosphereAutopilot/Modules/DirectorController.cs
@@ -77,6 +77,11 @@ namespace AtmosphereAutopilot
         [VesselSerializable("strength")]
         [AutoGuiAttr("strength", true, "G4")]
         public double strength = 0.95;
+        public string strength_as_text
+        {
+            set => this.strength = double.TryParse(value, out double v) ? v : this.strength;
+            get => this.strength.ToString("G4");
+        }
 
         [AutoGuiAttr("roll_stop_k", true, "G5")]
         public float roll_stop_k = 1.0f;

--- a/AtmosphereAutopilot/Modules/TopModuleManager.cs
+++ b/AtmosphereAutopilot/Modules/TopModuleManager.cs
@@ -17,7 +17,6 @@ along with Atmosphere Autopilot.  If not, see <http://www.gnu.org/licenses/>.
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEngine;
 using System.Reflection;
 
@@ -251,37 +250,37 @@ namespace AtmosphereAutopilot
                 // Moderation sections
                 GUILayout.BeginHorizontal();
                 pvc.moderate_aoa = GUILayout.Toggle(pvc.moderate_aoa, "Moderate AoA", GUIStyles.toggleButtonStyle);
-                float.TryParse(GUILayout.TextField(pvc.max_aoa.ToString("G4"), GUIStyles.textBoxStyle), out pvc.max_aoa);
+                pvc.max_aoa_as_text = GUILayout.TextField(pvc.max_aoa_as_text, GUIStyles.textBoxStyle);
                 GUILayout.EndHorizontal();
                 GUILayout.BeginHorizontal();
                 pvc.moderate_g = GUILayout.Toggle(pvc.moderate_g, "Moderate G", GUIStyles.toggleButtonStyle);
-                float.TryParse(GUILayout.TextField(pvc.max_g_force.ToString("G4"), GUIStyles.textBoxStyle), out pvc.max_g_force);
+                pvc.max_g_force_as_text = GUILayout.TextField(pvc.max_g_force_as_text, GUIStyles.textBoxStyle);
                 GUILayout.EndHorizontal();
                 GUILayout.BeginHorizontal();
                 yvc.moderate_aoa = GUILayout.Toggle(yvc.moderate_aoa, "Moderate Sideslip", GUIStyles.toggleButtonStyle);
-                float.TryParse(GUILayout.TextField(yvc.max_aoa.ToString("G4"), GUIStyles.textBoxStyle), out yvc.max_aoa);
+                yvc.max_aoa_as_text = GUILayout.TextField(yvc.max_aoa_as_text, GUIStyles.textBoxStyle);
                 GUILayout.EndHorizontal();
                 GUILayout.BeginHorizontal();
                 yvc.moderate_g = GUILayout.Toggle(yvc.moderate_g, "Moderate side-G", GUIStyles.toggleButtonStyle);
-                float.TryParse(GUILayout.TextField(yvc.max_g_force.ToString("G4"), GUIStyles.textBoxStyle), out yvc.max_g_force);
+                yvc.max_g_force_as_text = GUILayout.TextField(yvc.max_g_force_as_text, GUIStyles.textBoxStyle);
                 GUILayout.EndHorizontal();
 
                 // rotation rate limits
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("pitch rate limit", GUIStyles.labelStyleLeft);
-                float.TryParse(GUILayout.TextField(pvc.max_v_construction.ToString("G4"), GUIStyles.textBoxStyle), out pvc.max_v_construction);
+                pvc.max_v_construction_as_text = GUILayout.TextField(pvc.max_v_construction_as_text, GUIStyles.textBoxStyle);
                 GUILayout.EndHorizontal();
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("roll rate limit", GUIStyles.labelStyleLeft);
-                float.TryParse(GUILayout.TextField(rvc.max_v_construction.ToString("G4"), GUIStyles.textBoxStyle), out rvc.max_v_construction);
+                rvc.max_v_construction_as_text = GUILayout.TextField(rvc.max_v_construction_as_text, GUIStyles.textBoxStyle);
                 GUILayout.EndHorizontal();
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("yaw rate limit", GUIStyles.labelStyleLeft);
-                float.TryParse(GUILayout.TextField(yvc.max_v_construction.ToString("G4"), GUIStyles.textBoxStyle), out yvc.max_v_construction);
+                yvc.max_v_construction_as_text = GUILayout.TextField(yvc.max_v_construction_as_text, GUIStyles.textBoxStyle);
                 GUILayout.EndHorizontal();
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("director strength", GUIStyles.labelStyleLeft);
-                double.TryParse(GUILayout.TextField(dc.strength.ToString("G4"), GUIStyles.textBoxStyle), out dc.strength);
+                dc.strength_as_text = GUILayout.TextField(dc.strength_as_text, GUIStyles.textBoxStyle);
                 GUILayout.EndHorizontal();
 
                 // wing leveler


### PR DESCRIPTION
There's a nasty usability bug on the NeoGUI: if the user mistypes something (as entering a letter, or switching the `.` with a `,`, as it's usual on PT-BR keyboards), AA end up getting a completely screwed value on the field - with very nasty consequences.

> As a matter of fact, this just happened today while programming my ascent - and since I use the GPWS add'on, it happened with that terrifying "PULL UP" warning.
>
> Really, really spine freezing event.

To prevent this problem, I reworked the text input to reset to the previous valid value if en error is detected while parsing the input.

It appears to work fine until the moment - I'm currently testing the thing again (it's some time since I coded it, but I ended up forgetting to do the pull request)